### PR TITLE
Update installation doc for Mint and Bodhi linux

### DIFF
--- a/doc/sources/installation/installation-linux.rst
+++ b/doc/sources/installation/installation-linux.rst
@@ -71,7 +71,7 @@ Linux Mint
 ----------
 
 #. Find out on which Ubuntu release your installation is based on, using this
-   `overview <http://www.linuxmint.com/oldreleases.php>`_.
+   `overview <https://linuxmint.com/download_all.php>`_.
 #. Continue as described for Ubuntu above, depending on which version your
    installation is based on.
 
@@ -88,6 +88,8 @@ Bodhi Linux
         Ubuntu 12.04 LTS aka Precise
     :Bodhi 3:
         Ubuntu 14.04 LTS aka Trusty
+    :Bodhi 4:
+        Ubuntu 16.04 LTS aka Xenial
 
 
 2. Continue as described for Ubuntu above, depending on which version your installation is based on.


### PR DESCRIPTION
- Replacing outdated link for Linux Mint https://linuxmint.com/download_all.php
- Adding entry for Bodhi 4 release http://www.bodhilinux.com/2016/10/29/bodhi-linux-4-0-0-released/